### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1044,7 +1044,7 @@ class Timer {
   }
 
  private:
-  std::chrono::time_point<std::chrono::steady_clock> start_;
+  std::chrono::steady_clock::time_point start_;
 };
 
 // Returns a timestamp as milliseconds since the epoch. Note this time may jump


### PR DESCRIPTION
Googletest export

Use the time_point from steady_clock instead of the template
This fixes the build on some embedded compilers

PiperOrigin-RevId: 368879480
Change-Id: I5f61269b52a8040c8698bbc9a28b34d21696ca1c
GitOrigin-RevId: a7bc22f9e177e878385ad4780b32eb83e3efbaad